### PR TITLE
Fix LeadProsper function URLs

### DIFF
--- a/src/components/data-sources/LeadProsperIntegration.tsx
+++ b/src/components/data-sources/LeadProsperIntegration.tsx
@@ -9,6 +9,7 @@ import { Link, LinkIcon, CheckCircle2, XCircle, Loader2, AlertCircle } from "luc
 import { toast } from 'sonner';
 import LeadProsperCampaigns from './LeadProsperCampaigns';
 import { leadProsperApi } from "@/integrations/leadprosper/client";
+import { SUPABASE_FUNCTIONS_URL } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -57,7 +58,7 @@ const LeadProsperIntegration = () => {
       console.log("Starting verification process");
       
       // First try to verify the API key using the Edge Function
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
+      const response = await fetch(`${SUPABASE_FUNCTIONS_URL}/lead-prosper-verify`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -155,7 +156,7 @@ const LeadProsperIntegration = () => {
     
     try {
       console.log("Verifying API key only");
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
+      const response = await fetch(`${SUPABASE_FUNCTIONS_URL}/lead-prosper-verify`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/integrations/leadprosper/client.ts
+++ b/src/integrations/leadprosper/client.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from "@/integrations/supabase/client";
+import { supabase, SUPABASE_FUNCTIONS_URL } from "@/integrations/supabase/client";
 import { 
   LeadProsperCredentials, 
   LeadProsperCampaign, 
@@ -571,7 +571,7 @@ export const leadProsperApi = {
    * Get Lead Prosper webhook URL
    */
   getLeadProsperWebhookUrl(): string {
-    return `${window.location.origin}/api/webhook/leadprosper`;
+    return `${SUPABASE_FUNCTIONS_URL}/lead-prosper-webhook`;
   },
 
   /**
@@ -585,7 +585,7 @@ export const leadProsperApi = {
     endDate: string
   ): Promise<LeadProsperLeadProcessingResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-backfill`, {
+      const response = await fetch(`${SUPABASE_FUNCTIONS_URL}/lead-prosper-backfill`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -615,7 +615,7 @@ export const leadProsperApi = {
    */
   async fetchTodayLeads(): Promise<LeadProsperSyncResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-fetch-today`, {
+      const response = await fetch(`${SUPABASE_FUNCTIONS_URL}/lead-prosper-fetch-today`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -24,3 +24,6 @@ export const supabase = createClient<Database>(
 
 // Export the Supabase URL for Edge Functions
 export const SUPABASE_PROJECT_URL = SUPABASE_URL;
+
+// Base URL for calling Supabase Edge Functions
+export const SUPABASE_FUNCTIONS_URL = `${SUPABASE_URL}/functions/v1`;


### PR DESCRIPTION
## Summary
- adjust LeadProsper integration to call Supabase Edge Functions directly
- expose `SUPABASE_FUNCTIONS_URL` constant for function URLs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*