### PR TITLE
Redirect integrations to data sources

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import AuthPage from "./pages/AuthPage";
 import NotFound from "./pages/NotFound";
 import BuyersPage from "./pages/BuyersPage";
 import LeadsPage from "./pages/LeadsPage";
+import RedirectIntegrations from "./components/RedirectIntegrations";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -71,8 +72,8 @@ const App = () => (
               {/* Redirect /campaign to /campaigns to fix 404 issues */}
               <Route path="/campaign" element={<Navigate to="/campaigns" replace />} />
               
-              {/* Redirect /integrations to /data-sources */}
-              <Route path="/integrations" element={<Navigate to="/data-sources" replace />} />
+              {/* Redirect /integrations to /data-sources while preserving query params */}
+              <Route path="/integrations" element={<RedirectIntegrations />} />
               
               {/* All other routes are protected and wrapped with MainLayout */}
               <Route element={

--- a/src/components/RedirectIntegrations.tsx
+++ b/src/components/RedirectIntegrations.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+export default function RedirectIntegrations() {
+  const location = useLocation();
+  return <Navigate to={`/data-sources${location.search}`} />;
+}


### PR DESCRIPTION
## Summary
- add `RedirectIntegrations` component for route forwarding
- update `/integrations` route to use component

## Testing
- `npm run lint` *(fails: Cannot find module 'globals')*