### PR TITLE
Switch LeadProsper calls to Supabase

### DIFF
--- a/src/components/data-sources/LeadProsperIntegration.tsx
+++ b/src/components/data-sources/LeadProsperIntegration.tsx
@@ -9,6 +9,7 @@ import { Link, LinkIcon, CheckCircle2, XCircle, Loader2, AlertCircle } from "luc
 import { toast } from 'sonner';
 import LeadProsperCampaigns from './LeadProsperCampaigns';
 import { leadProsperApi } from "@/integrations/leadprosper/client";
+import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -56,17 +57,16 @@ const LeadProsperIntegration = () => {
     try {
       console.log("Starting verification process");
       
-      // First try to verify the API key using the Edge Function
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ apiKey }),
+      // First try to verify the API key using the Edge Function via Supabase
+      const { data, error } = await supabase.functions.invoke('lead-prosper-verify', {
+        body: { apiKey }
       });
-      
-      console.log("Verification response status:", response.status);
-      const verifyResult = await response.json();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      const verifyResult = typeof data === 'string' ? JSON.parse(data) : data;
       console.log("Verification result:", verifyResult);
       
       if (!verifyResult.isValid) {
@@ -155,16 +155,15 @@ const LeadProsperIntegration = () => {
     
     try {
       console.log("Verifying API key only");
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ apiKey }),
+      const { data, error } = await supabase.functions.invoke('lead-prosper-verify', {
+        body: { apiKey }
       });
-      
-      console.log("Verification response status:", response.status);
-      const verifyResult = await response.json();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      const verifyResult = typeof data === 'string' ? JSON.parse(data) : data;
       console.log("Verification result:", verifyResult);
       
       if (verifyResult.isValid) {

--- a/src/integrations/leadprosper/client.ts
+++ b/src/integrations/leadprosper/client.ts
@@ -585,25 +585,21 @@ export const leadProsperApi = {
     endDate: string
   ): Promise<LeadProsperLeadProcessingResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-backfill`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
+      const { data, error } = await supabase.functions.invoke('lead-prosper-backfill', {
+        body: {
           apiKey,
           lpCampaignId,
           tsCampaignId,
           startDate,
           endDate
-        })
+        }
       });
-      
-      if (!response.ok) {
-        throw new Error(`Backfill API error: ${response.status} ${response.statusText}`);
+
+      if (error) {
+        throw new Error(error.message);
       }
-      
-      return await response.json();
+
+      return typeof data === 'string' ? JSON.parse(data) : data;
     } catch (error) {
       console.error('Error backfilling leads:', error);
       throw error;
@@ -615,18 +611,15 @@ export const leadProsperApi = {
    */
   async fetchTodayLeads(): Promise<LeadProsperSyncResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-fetch-today`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
+      const { data, error } = await supabase.functions.invoke('lead-prosper-fetch-today', {
+        body: {}
       });
-      
-      if (!response.ok) {
-        throw new Error(`API error: ${response.status} ${response.statusText}`);
+
+      if (error) {
+        throw new Error(error.message);
       }
-      
-      return await response.json();
+
+      return typeof data === 'string' ? JSON.parse(data) : data;
     } catch (error) {
       console.error('Error fetching today\'s leads:', error);
       throw {


### PR DESCRIPTION
## Summary
- verify Lead Prosper API keys with `supabase.functions.invoke`
- invoke backfill/today functions with Supabase client

## Testing
- `npm run lint` *(fails: Cannot find module 'globals')*