### PR TITLE
Use supabase invoke for LeadProsper edge calls

### DIFF
--- a/src/components/data-sources/LeadProsperIntegration.tsx
+++ b/src/components/data-sources/LeadProsperIntegration.tsx
@@ -11,6 +11,7 @@ import LeadProsperCampaigns from './LeadProsperCampaigns';
 import { leadProsperApi } from "@/integrations/leadprosper/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { supabase } from "@/integrations/supabase/client";
 
 const LeadProsperIntegration = () => {
   const { user } = useAuth();
@@ -57,16 +58,14 @@ const LeadProsperIntegration = () => {
       console.log("Starting verification process");
       
       // First try to verify the API key using the Edge Function
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ apiKey }),
+      const { data: verifyResult, error } = await supabase.functions.invoke('lead-prosper-verify', {
+        body: { apiKey }
       });
-      
-      console.log("Verification response status:", response.status);
-      const verifyResult = await response.json();
+
+      if (error) {
+        console.error('Verification error:', error);
+      }
+
       console.log("Verification result:", verifyResult);
       
       if (!verifyResult.isValid) {
@@ -155,16 +154,14 @@ const LeadProsperIntegration = () => {
     
     try {
       console.log("Verifying API key only");
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-verify`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ apiKey }),
+      const { data: verifyResult, error } = await supabase.functions.invoke('lead-prosper-verify', {
+        body: { apiKey }
       });
-      
-      console.log("Verification response status:", response.status);
-      const verifyResult = await response.json();
+
+      if (error) {
+        console.error('Verification error:', error);
+      }
+
       console.log("Verification result:", verifyResult);
       
       if (verifyResult.isValid) {

--- a/src/integrations/leadprosper/client.ts
+++ b/src/integrations/leadprosper/client.ts
@@ -585,25 +585,21 @@ export const leadProsperApi = {
     endDate: string
   ): Promise<LeadProsperLeadProcessingResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-backfill`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
+      const { data, error } = await supabase.functions.invoke('lead-prosper-backfill', {
+        body: {
           apiKey,
           lpCampaignId,
           tsCampaignId,
           startDate,
           endDate
-        })
+        }
       });
-      
-      if (!response.ok) {
-        throw new Error(`Backfill API error: ${response.status} ${response.statusText}`);
+
+      if (error) {
+        throw new Error(`Backfill API error: ${error.message}`);
       }
-      
-      return await response.json();
+
+      return data as LeadProsperLeadProcessingResult;
     } catch (error) {
       console.error('Error backfilling leads:', error);
       throw error;
@@ -615,18 +611,13 @@ export const leadProsperApi = {
    */
   async fetchTodayLeads(): Promise<LeadProsperSyncResult> {
     try {
-      const response = await fetch(`${window.location.origin}/functions/lead-prosper-fetch-today`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-      
-      if (!response.ok) {
-        throw new Error(`API error: ${response.status} ${response.statusText}`);
+      const { data, error } = await supabase.functions.invoke('lead-prosper-fetch-today');
+
+      if (error) {
+        throw new Error(`API error: ${error.message}`);
       }
-      
-      return await response.json();
+
+      return data as LeadProsperSyncResult;
     } catch (error) {
       console.error('Error fetching today\'s leads:', error);
       throw {


### PR DESCRIPTION
## Summary
- use Supabase client inside `LeadProsperIntegration`
- call edge functions with `supabase.functions.invoke` instead of `fetch`
- refactor LeadProsper client methods to use Supabase

## Testing
- `npm run lint` *(fails: could not find plugin "react-hooks")*